### PR TITLE
Remove "title" attribute from atlas.json

### DIFF
--- a/atlas.json
+++ b/atlas.json
@@ -19,6 +19,5 @@
       "toc": true
     }
   },
-  "theme": "https://github.com/oreillymedia/atlas_tech1c_theme.git",
-  "title": "atlas book skeleton"
+  "theme": "https://github.com/oreillymedia/atlas_tech1c_theme.git"
 }


### PR DESCRIPTION
Now when someone creates a new project and builds, the title will be blank.

This will fix the issue where "atlas book skeleton" shows up as a default title instead of the project name. Blanks is better than the wrong title.
