### PR TITLE
changing the sample caption to get rid of "Caption:"

### DIFF
--- a/05-chapter.html
+++ b/05-chapter.html
@@ -23,7 +23,7 @@
 <p>Now, let's take a look at a figure with a caption:</p>
 
 <figure><img src="images/figure.jpg" />
-<figcaption>Caption: This is a picture of my friend Mike's cat.</figcaption>
+<figcaption>This is a caption describing the picture of my friend Mike's cat.</figcaption>
 </figure>
 
 <section data-type="sect2">


### PR DESCRIPTION
Ally alerted me to this. Authors think they need to write "Caption:" on each figure.