### PR TITLE
Setting templating to be false by default.

### DIFF
--- a/atlas.json
+++ b/atlas.json
@@ -19,6 +19,7 @@
       "toc": true
     }
   },
+  "templating": false,
   "theme": "oreillymedia/atlas_tech1c_theme",
   "title": "atlas book skeleton"
 }


### PR DESCRIPTION
Setting templating to be false by default, because we've found that in the majority of cases, book project owners are not using the templating features in book content, and we're very frequently needing to explicitly disable them to avoid having to escape literal curly braces in content (which comes up very frequently in technical content).

Speak up if you disagree with this change :)