### PR TITLE
Update atlas.json

### DIFF
--- a/atlas.json
+++ b/atlas.json
@@ -16,7 +16,8 @@
       "toc": true,
       "index": true,
       "syntaxhighlighting": true,
-      "show_comments": false
+      "show_comments": false,
+      "antennahouse_version": "AHFormatterV62_64-MR4"
     },
     "epub": {
       "toc": true,


### PR DESCRIPTION
Specifying MR4 as the AH version in the default Configuration for Atlas projects