### PR TITLE
Replacing math PNGs with MathML

### DIFF
--- a/atlas.json
+++ b/atlas.json
@@ -24,7 +24,8 @@
       "index": true,
       "syntaxhighlighting": true,
       "epubcheck": true,
-      "show_comments": false
+      "show_comments": false,
+      "mathmlreplace": false
     },
     "mobi": {
       "toc": true,


### PR DESCRIPTION
Setting the default for projects created with "Book" option in Atlas to bypass converting MathML to PNGs. MathML can be more attractively formatted in Safari.